### PR TITLE
Moved activitiy control to model, removed observer

### DIFF
--- a/src/app/code/community/Divido/Pay/Model/Observer.php
+++ b/src/app/code/community/Divido/Pay/Model/Observer.php
@@ -36,28 +36,4 @@ class Divido_Pay_Model_Observer
 
 
     }
-
-    public function toggleDividoAvailability (Varien_Event_Observer $observer)
-    {
-        $quote        = $observer->quote;
-
-        // Only interesting if run in the context of a quote;
-        if (! $quote) {
-            return;
-        }
-
-        $event        = $observer->getEvent();
-        $method       = $event->getMethodInstance();
-        $result       = $event->getResult();
-
-        $plans        = Mage::helper('pay')->getQuotePlans($quote);
-
-        $billingAddr  = $quote->getBillingAddress()->getData();
-        $rightCountry = $billingAddr['country_id'] == 'GB';
-
-
-        if ($method->getCode() == 'pay' && (!$rightCountry || empty($plans))) {
-            $result->isAvailable = false;
-        }
-    }
 }

--- a/src/app/code/community/Divido/Pay/Model/Standard.php
+++ b/src/app/code/community/Divido/Pay/Model/Standard.php
@@ -108,5 +108,14 @@ class Divido_Pay_Model_Standard extends Mage_Payment_Model_Method_Abstract
     {
         return $this->getCheckout()->getQuote();
     }
+
+    public function isAvailable ($quote = null)
+    {
+        $hasPlans     = Mage::helper('pay')->getQuotePlans($quote);
+        $billingAddr  = $quote->getBillingAddress()->getData();
+        $rightCountry = $billingAddr['country_id'] == 'GB';
+
+        return $hasPlans && $rightCountry;
+    }
 }
 ?>

--- a/src/app/code/community/Divido/Pay/controllers/PaymentController.php
+++ b/src/app/code/community/Divido/Pay/controllers/PaymentController.php
@@ -41,6 +41,7 @@ class Divido_Pay_PaymentController extends Mage_Core_Controller_Front_Action
         $item_quote     = Mage::getModel('checkout/cart')->getQuote();
         $items_in_cart  = $item_quote->getAllItems();
         $products       = array();
+
         foreach ($items_in_cart as $item) {
             $item_qty      = $item->getQty();
             $item_value    = $item->getPrice();

--- a/src/app/code/community/Divido/Pay/etc/config.xml
+++ b/src/app/code/community/Divido/Pay/etc/config.xml
@@ -128,15 +128,5 @@
                 </divido_pay>
             </updates>
         </layout>
-        <events>
-            <payment_method_is_active>
-                <observers>
-                    <toggleDividoAvailability>
-                        <class>Divido_Pay_Model_Observer</class>
-                        <method>toggleDividoAvailability</method>
-                    </toggleDividoAvailability>
-                </observers>
-            </payment_method_is_active>
-        </events>
     </frontend>
 </config>

--- a/src/divido_callback.php
+++ b/src/divido_callback.php
@@ -38,7 +38,6 @@ if ($hash !== $data->metadata->quote_hash) {
     exit('Cannot verify request');
 }
 
-
 $order = Mage::getModel('sales/order')->loadByAttribute('quote_id', $data->metadata->quote_id);
 
 if (! $order->getId()) {


### PR DESCRIPTION
Used more magentoesque way of determining whether or not to show the
Divido payment gateway at checkout. Observer was called way to often.