### PR TITLE
Added quote ID to return url

### DIFF
--- a/src/app/code/community/Divido/Pay/controllers/PaymentController.php
+++ b/src/app/code/community/Divido/Pay/controllers/PaymentController.php
@@ -122,7 +122,7 @@ class Divido_Pay_PaymentController extends Mage_Core_Controller_Front_Action
             'products'     => $products,
             'response_url' => Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB) . 'divido_callback.php',
             'checkout_url' => Mage::helper('checkout/url')->getCheckoutUrl(),
-            'redirect_url' => Mage::getUrl('pay/payment/return'),
+            'redirect_url' => Mage::getUrl('pay/payment/return', array('quote_id' => $quote_id)),
         );
 
         $response = Divido_CreditRequest::create($request_data);


### PR DESCRIPTION
When returning from Divido, set quote ID in QS to be able to pick the
quote up and go to success page.