### PR TITLE
Update Divido.php to allow for PHP 5.3 compatibility

### DIFF
--- a/lib/Divido/Divido/Divido.php
+++ b/lib/Divido/Divido/Divido.php
@@ -136,7 +136,7 @@ abstract class Divido
       self::$apiBase = self::$testingApiBase;
     } else if (substr($apiKey,0,7) == 'staging') {
       self::$apiBase = self::$sandboxApiBase;
-    } else if (in_array(substr($apiKey, 0, 3), ['doc', 'dev'])) {
+    } else if (in_array(substr($apiKey, 0, 3), array('doc', 'dev'))) {
       self::$apiBase = self::$devApiBase;
     } else if (substr($apiKey,0,7) == 'sandbox') {
       self::$apiBase = self::$sandboxApiBase;


### PR DESCRIPTION
Previous versions of this module worked on PHP 5.3. This file causes a 500 error due to the use of brackets which are only allowed in PHP 5.4 onwards.